### PR TITLE
Use StdRng instead of ThreadRng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "elevate-lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rand",
  "statrs",

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -4,7 +4,7 @@ use crate::floors::Floors;
 use crate::people::People;
 
 //Implement standard/imported modules
-use rand::rngs::ThreadRng;
+use rand::rngs::StdRng;
 use rand::distributions::{Distribution, Uniform};
 
 /// # `ElevatorController` trait
@@ -23,12 +23,12 @@ pub trait ElevatorController {
     pub building: Building,
     floors_to: Vec<Option<usize>>,
     dst_to: Uniform<usize>,
-    rng: ThreadRng
+    rng: StdRng
 }
 
 //Implement the RandomController interface
 impl RandomController {
-    /// Initialize a new RandomController given a `Building` and a `ThreadRng` (from
+    /// Initialize a new RandomController given a `Building` and a `StdRng` (from
     /// the rand library).
     ///
     /// ## Example
@@ -48,7 +48,7 @@ impl RandomController {
     ///     my_rng
     /// );
     /// ```
-    pub fn from(building: Building, rng: ThreadRng) -> RandomController {
+    pub fn from(building: Building, rng: StdRng) -> RandomController {
         //Get the number of floors and elevators in the building
         let num_floors: usize = building.floors.len();
         let num_elevators: usize = building.elevators.len();


### PR DESCRIPTION
In this PR, I remove all instances of `ThreadRng` from the controller structs so that they can be embedded in a `Mutex` for WASM implementations on top of the library.