### PR TITLE
Enable tip collection & RandomController rationality upgrade system

### DIFF
--- a/src/building.rs
+++ b/src/building.rs
@@ -223,6 +223,13 @@ impl Building {
         self.tot_tips += tip_value;
     }
 
+    /// Returns all tips collected by the building, and resets the total tips to 0
+    pub fn collect_tips(&mut self) -> f64 {
+        let tips: f64 = self.tot_tips;
+        self.tot_tips = 0.0_f64;
+        tips
+    }
+
     /// Update the average energy spent by the building's elevators given the time
     /// step and the energy spent during the time step.
     pub fn update_average_energy(&mut self, time_step: i32, energy_spent: f64) {
@@ -277,7 +284,7 @@ impl std::fmt::Display for Building {
         let wait_time_str: String = format!("Average wait time:\t{:.2}", self.avg_wait_time);
         let energy_str: String = format!("Average energy spent:\t{:.2}", self.avg_energy);
         let tip_str: String = format!("Total tips collected:\t${:.2}", self.tot_tips);
-        building_status = [building_status, wait_time_str, energy_str].join("\n");
+        building_status = [building_status, wait_time_str, energy_str, tip_str].join("\n");
 
         //Format the string and return
         f.write_str(&building_status)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,7 +5,7 @@ use crate::people::People;
 
 //Implement standard/imported modules
 use rand::rngs::StdRng;
-use rand::distributions::{Distribution, Uniform};
+use rand::distributions::{Distribution, Uniform, Bernoulli};
 
 /// # `ElevatorController` trait
 ///
@@ -14,6 +14,12 @@ pub trait ElevatorController {
     fn get_building(&mut self) -> &Building;
 
     fn get_building_mut(&mut self) -> &mut Building;
+
+    fn clone_building(&mut self) -> Building;
+
+    fn can_be_upgraded(&self) -> bool;
+
+    fn upgrade(&mut self, incrementation: f64);
 
     fn update_elevators(&mut self);
 }
@@ -27,6 +33,9 @@ pub trait ElevatorController {
     pub building: Building,
     floors_to: Vec<Option<usize>>,
     dst_to: Uniform<usize>,
+    p_rational: f64,
+    dst_rational: Bernoulli,
+    upgradable: bool,
     rng: StdRng
 }
 
@@ -49,10 +58,11 @@ impl RandomController {
     /// );
     /// let my_controller: RandomController = RandomController::from(
     ///     my_building,
-    ///     my_rng
+    ///     my_rng,
+    ///     0.5_f64
     /// );
     /// ```
-    pub fn from(building: Building, rng: StdRng) -> RandomController {
+    pub fn from(building: Building, rng: StdRng, p_rational: f64) -> RandomController {
         //Get the number of floors and elevators in the building
         let num_floors: usize = building.floors.len();
         let num_elevators: usize = building.elevators.len();
@@ -74,7 +84,61 @@ impl RandomController {
             building: building,
             floors_to: floors_to,
             dst_to: dst_to,
+            p_rational: p_rational,
+            dst_rational: Bernoulli::new(p_rational).unwrap(),
+            upgradable: true,
             rng: rng
+        }
+    }
+
+    /// Set the destination floors of the elevators randomly according to
+    /// random or rational logic, depending on the p_rational
+    pub fn update_floors_to(&mut self) {
+        //Loop through the elevators in the building
+        for (i, elevator) in self.building.elevators.iter().enumerate() {
+            //If the destination floor for the elevator is None, then update it
+            match self.floors_to[i] {
+                Some(_) => {},
+                None => {
+                    if self.dst_rational.sample(&mut self.rng) {
+                        if elevator.stopped {
+                            //Find the nearest destination floor among people on the elevator
+                            let (nearest_dest_floor, min_dest_floor_dist): (usize, usize) = elevator.get_nearest_dest_floor();
+                
+                            //If the nearest dest floor is identified, then set as the dest floor
+                            if min_dest_floor_dist != 0_usize {
+                                self.floors_to[i] = Some(nearest_dest_floor);
+                                continue;
+                            }
+                
+                            //Find the nearest waiting floor among people throughout the building
+                            let (nearest_wait_floor, min_wait_floor_dist): (usize, usize) = self.building.get_nearest_wait_floor(elevator.floor_on);
+                
+                            //If the nearest wait floor is identified, then set as the dest floor
+                            if min_wait_floor_dist != 0_usize {
+                                self.floors_to[i] = Some(nearest_wait_floor);
+                                continue;
+                            }
+                        }
+                    } else {
+                        self.floors_to[i] = Some(self.dst_to.sample(&mut self.rng));
+                        continue;
+                    }
+                    self.floors_to[i] = Some(elevator.floor_on);
+                }
+            }
+        }
+    }
+
+    /// If any elevators are at their destination floor, then set that floor
+    /// to None so that it can be re-randomized next time step.
+    pub fn clear_floors_to(&mut self) {
+        //Loop through the elevators in the building
+        for (i, elevator) in self.building.elevators.iter().enumerate() {
+            let dest_floor = self.floors_to[i].unwrap();
+            if dest_floor == elevator.floor_on {
+                self.floors_to[i] = None;
+            }
         }
     }
 }
@@ -91,35 +155,61 @@ impl ElevatorController for RandomController {
         &mut self.building
     }
 
+    /// Clone the building belonging to the controller.  Generally used when
+    /// swapping controllers.
+    fn clone_building(&mut self) -> Building {
+        self.building.clone()
+    }
+
+    /// Return a boolean signifying whether the controller can be upgraded or
+    /// not.
+    fn can_be_upgraded(&self) -> bool {
+        //If the controller is 100% rational, then no further upgrades are
+        //possible
+        if self.p_rational >= 1.0_f64 {
+            return false;
+        }
+
+        //Otherwise, the elevator controller can be upgraded
+        self.upgradable
+    }
+
+    /// Upgrade the controller given an incrementation float
+    fn upgrade(&mut self, incrementation: f64) {
+        //Add the current rationality probability to the incrementation and
+        //check to see if it exceeds 1, if so then ceiling it at 1.0
+        let mut new_p_rational: f64 = self.p_rational + incrementation;
+        if new_p_rational > 1.0_f64 {
+            new_p_rational = 1.0_f64;
+        }
+
+        //Update the rationality probability and distribution of the controller
+        self.p_rational = new_p_rational;
+        self.dst_rational = Bernoulli::new(self.p_rational).unwrap();
+    }
+
     /// If the destination floor is None, then randomize a new destination floor.
     /// If the elevator is not on its destination floor then move toward it.  If the
     /// elevator is on its destination floor then stop it and set its destination
     /// floor to None for randomization during the next step.
     fn update_elevators(&mut self) {
-        //Loop through the elevators in the building
-        for (i, elevator) in self.building.elevators.iter_mut().enumerate() {
-            //If the destination floor for the elevator is None, then randomize it
-            let floor_to: usize = match self.floors_to[i] {
-                Some(x) => x as usize,
-                None => self.dst_to.sample(&mut self.rng)
-            };
+        //Update the destination floors
+        self.update_floors_to();
+        
+        //Loop through the dest floors and update the building's elevators accordingly
+        for (i, floor_to) in self.floors_to.iter().enumerate() {
+            //Unwrap the destination floor
+            let dest_floor: usize = floor_to.unwrap();
 
-            //If the elevator is not on its destination floor, then move toward it
-            if floor_to > elevator.floor_on {
-                elevator.stopped = false;
-                elevator.moving_up = true;
-            } else if floor_to < elevator.floor_on {
-                elevator.stopped = false;
-                elevator.moving_up = false;
-            //If the elevator is on its destination floor, then stop and set is destination floor to None
-            } else {
-                elevator.stopped = true;
-                self.floors_to[i] = None;
-            }
+            //Update the elevator's direction based on its destination floor
+            self.building.elevators[i].update_direction(dest_floor);
 
             //Update the elevator
-            let _new_floor_index = elevator.update_floor();
+            let _new_floor_index = self.building.elevators[i].update_floor();
         }
+
+        //Clear the destination floors if any elevators arrived at their destinations
+        self.clear_floors_to();
     }
 }
 
@@ -129,7 +219,8 @@ impl ElevatorController for RandomController {
 /// elevator's direction based on the nearest destination floor among people on the
 /// elevator, then the nearest floor with people waiting.
 pub struct NearestController {
-    pub building: Building
+    pub building: Building,
+    upgradable: bool
 }
 
 //Implement the NearestController interface
@@ -152,7 +243,8 @@ impl NearestController {
     pub fn from(building: Building) -> NearestController {
         //Initialize the controller
         NearestController {
-            building: building
+            building: building,
+            upgradable: false
         }
     }
 }
@@ -169,11 +261,28 @@ impl ElevatorController for NearestController {
         &mut self.building
     }
 
+    /// Clone the building belonging to the controller.  Generally used when
+    /// swapping controllers.
+    fn clone_building(&mut self) -> Building {
+        self.building.clone()
+    }
+
+    /// Return a boolean signifying whether the controller can be upgraded or
+    /// not.  Always returns false, since the NearestController cannot be
+    /// upgraded.
+    fn can_be_upgraded(&self) -> bool {
+        self.upgradable
+    }
+
+    /// Upgrade the controller given an incrementation float.  Does nothing for
+    /// the NearestController since it cannot be upgraded.
+    fn upgrade(&mut self, _incrementation: f64) {}
+
     /// Decide each elevator's direction based on the nearest destination floor among
     /// people on the elevator, then the nearest floor with people waiting.
     fn update_elevators(&mut self) {
         //Initialize a vector of decisions for the elevators
-        let mut elevator_decisions: Vec<i32> = Vec::new();
+        let mut elevator_decisions: Vec<usize> = Vec::new();
 
         //Loop through the elevators in the building
         for elevator in self.building.elevators.iter() {
@@ -184,14 +293,8 @@ impl ElevatorController for NearestController {
 
                 //If the nearest dest floor is identified, then update the elevator
                 if min_dest_floor_dist != 0_usize {
-                    //Unstop the elevator and move toward the nearest dest floor
-                    if nearest_dest_floor > elevator.floor_on {
-                        elevator_decisions.push(1_i32);
-                        continue;
-                    } else {
-                        elevator_decisions.push(-1_i32);
-                        continue;
-                    }
+                    elevator_decisions.push(nearest_dest_floor);
+                    continue;
                 }
 
                 //Find the nearest waiting floor among people throughout the building
@@ -199,66 +302,43 @@ impl ElevatorController for NearestController {
 
                 //If the nearest wait floor is identified, then update the elevator
                 if min_wait_floor_dist != 0_usize {
-                    //Unstop the elevator and move toward the nearest dest floor
-                    if nearest_wait_floor > elevator.floor_on {
-                        elevator_decisions.push(1_i32);
-                        continue;
-                    } else {
-                        elevator_decisions.push(-1_i32);
-                        continue;
-                    }
+                    elevator_decisions.push(nearest_wait_floor);
+                    continue;
                 }
             } else {
                 //If moving down and on the bottom floor, then stop
                 if !elevator.moving_up && elevator.floor_on == 0_usize {
-                    elevator_decisions.push(0_i32);
+                    elevator_decisions.push(elevator.floor_on);
                     continue;
                 }
 
                 //If moving up and on the top floor, then stop
                 if elevator.moving_up && elevator.floor_on == (self.building.floors.len() - 1_usize) {
-                    elevator_decisions.push(0_i32);
-                    continue;
-                }
-
-                //If there are people waiting on the current floor, then stop
-                if self.building.are_people_waiting_on_floor(elevator.floor_on) {
-                    elevator_decisions.push(0_i32);
+                    elevator_decisions.push(elevator.floor_on);
                     continue;
                 }
 
                 //If there are people waiting on the elevator for the current floor, then stop
                 if elevator.are_people_going_to_floor(elevator.floor_on) {
-                    elevator_decisions.push(0_i32);
+                    elevator_decisions.push(elevator.floor_on);
+                    continue;
+                }
+
+                //If there are people waiting on the current floor, then stop
+                if self.building.are_people_waiting_on_floor(elevator.floor_on) {
+                    elevator_decisions.push(elevator.floor_on);
                     continue;
                 }
             }
 
             //If we make it this far without returning, then return the current state
-            if elevator.stopped {
-                elevator_decisions.push(0_i32);
-                continue;
-            } else if elevator.moving_up {
-                elevator_decisions.push(1_i32);
-                continue;
-            } else {
-                elevator_decisions.push(-1_i32);
-                continue;
-            }
+            elevator_decisions.push(elevator.floor_on);
         }
 
         //Loop through the elevator decisions and update the elevators
         for (i, decision) in elevator_decisions.iter().enumerate() {
             //Update the elevator direction
-            if *decision > 0_i32 {
-                self.building.elevators[i].stopped = false;
-                self.building.elevators[i].moving_up = true;
-            } else if *decision < 0_i32 {
-                self.building.elevators[i].stopped = false;
-                self.building.elevators[i].moving_up = false;
-            } else {
-                self.building.elevators[i].stopped = true;
-            }
+            self.building.elevators[i].update_direction(*decision);
 
             //Update the elevator
             let _new_floor_index = self.building.elevators[i].update_floor();

--- a/src/elevator.rs
+++ b/src/elevator.rs
@@ -1,3 +1,6 @@
+//Import standard/imported modules
+use rand::Rng;
+
 //Import source modules
 use crate::person::Person;
 use crate::people::People;
@@ -7,6 +10,7 @@ use crate::people::People;
 /// An `Elevator` is aggregated by buildings, and transports people between floors.
 /// The `Elevator` struct generally should not be directly instantiated; instead it
 /// should be managed via the `Building` type and `ElevatorController` implementations.
+#[derive(Clone)]
 pub struct Elevator {
     pub floor_on: usize,
     pub moving_up: bool,
@@ -59,6 +63,24 @@ impl Elevator {
             };
         energy_spent
     }
+
+    /// Update the `stopped` and `moving_up` properties of the elevator given a
+    /// destination floor for the elevator.  The properties will be set such that
+    /// the elevator moves in the direction of the provided floor with respect to
+    /// its current floor when updated.
+    pub fn update_direction(&mut self, floor_to: usize) {
+        //If the elevator is not on its destination floor, then move toward it
+        if floor_to > self.floor_on {
+            self.stopped = false;
+            self.moving_up = true;
+        } else if floor_to < self.floor_on {
+            self.stopped = false;
+            self.moving_up = false;
+        //If the elevator is on its destination floor, then stop
+        } else {
+            self.stopped = true;
+        }
+    } 
 
     /// Use the `stopped` and `moving_up` properties of the elevator to update the
     /// elevator's floor index.  If stopped, then no change.  If moving up then
@@ -168,6 +190,11 @@ impl Extend<Person> for Elevator {
 
 //Implement the people trait for the elevator struct
 impl People for Elevator {
+    /// Generates the number of people among the collection of people who will tip.
+    fn gen_num_tips(&self, rng: &mut impl Rng) -> usize {
+        self.people.gen_num_tips(rng)
+    }
+
     /// Determines the destination floors for all people and returns it as a vector.
     fn get_dest_floors(&self) -> Vec<usize> {
         self.people.get_dest_floors()

--- a/src/floors.rs
+++ b/src/floors.rs
@@ -1,5 +1,6 @@
 //Import source modules
 use crate::floor::Floor;
+use crate::person::Person;
 use crate::people::People;
 
 //Import external/standard modules
@@ -29,7 +30,7 @@ pub trait Floors {
     fn gen_people_leaving(&mut self, rng: &mut impl Rng);
 
     /// Expected to remove anyone who is leaving the first floor.
-    fn flush_first_floor(&mut self);
+    fn flush_first_floor(&mut self) -> Vec<Person>;
 
     /// Expected to increment the waiting times among people who are waiting/not at their
     /// destination floor throughout the collection of floors.
@@ -110,9 +111,10 @@ impl Floors for Vec<Floor> {
         }
     }
 
-    /// Removes anyone who is leaving the first floor.
-    fn flush_first_floor(&mut self) {
-        self[0].flush_people_leaving_floor();
+    /// Removes anyone who is leaving the first floor and returns the people who left as
+    /// a vec of people.
+    fn flush_first_floor(&mut self) -> Vec<Person> {
+        self[0].flush_people_leaving_floor()
     }
 
     /// Increments the waiting times among people who are waiting/not at their destination

--- a/src/people.rs
+++ b/src/people.rs
@@ -1,3 +1,6 @@
+//Import standard/imported modules
+use rand::Rng;
+
 //Import source modules
 use crate::person::Person;
 
@@ -7,6 +10,9 @@ use crate::person::Person;
 /// implemented by the `Elevator` and `Floor` structs.  It defines a set of functions
 /// for managing `Person`s in aggregate.
 pub trait People {
+    /// Expected to generate the number of tips to collect from the people
+    fn gen_num_tips(&self, rng: &mut impl Rng) -> usize;
+
     /// Expected to determine the destination floors for all people and return it as
     /// a vector.
     fn get_dest_floors(&self) -> Vec<usize>;
@@ -40,6 +46,22 @@ pub trait People {
 }
 
 impl People for Vec<Person> {
+    /// Generates the number of people among the collection of people who will tip.
+    fn gen_num_tips(&self, rng: &mut impl Rng) -> usize {
+        //Initialize a counter for the number of people who will tip
+        let mut num_tips: usize = 0_usize;
+
+        //Loop through the people and generate whether each person will tip
+        for pers in self.iter() {
+            if pers.gen_tip(rng) {
+                num_tips += 1_usize;
+            }
+        }
+
+        //Return the counter
+        num_tips
+    }
+
     /// Determines the destination floors for all people and returns it as a vector.
     fn get_dest_floors(&self) -> Vec<usize> {
         //Initialize a new vector of usizes


### PR DESCRIPTION
In this PR, I implement the following features
- The `RandomController` can behave rationally sometimes according to a new property, `p_rational`.  This is to enable a controller upgrade system once the player buys the "auto-controller" upgrade in the universal elevators game.
- `Person`s randomly decide to tip when leaving the building, tips are stored in the `Building` struct and tracked over time.

For reference, see: https://github.com/whatsacomputertho/universal-elevators-web/blob/main/doc/spec.md