### PR TITLE
Enable appending new floors & elevators to a building

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevate-lib"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "An elevator simulation library for Rust"

--- a/src/building.rs
+++ b/src/building.rs
@@ -239,6 +239,11 @@ impl Building {
             tmp_num / tmp_denom
         };
     }
+
+    /// Append a new elevator to the building
+    pub fn append_elevator(&mut self, energy_up: f64, energy_down: f64, energy_coef: f64) {
+        self.elevators.push(Elevator::from(energy_up, energy_down, energy_coef));
+    }
 }
 
 //Display trait implementation for a building
@@ -329,5 +334,10 @@ impl Floors for Building {
     fn increment_wait_times(&mut self) {
         self.elevators.increment_wait_times();
         self.floors.increment_wait_times();
+    }
+
+    /// Appends a new floor to the building.
+    fn append_floor(&mut self) {
+        self.floors.append_floor();
     }
 }

--- a/src/elevators.rs
+++ b/src/elevators.rs
@@ -17,6 +17,8 @@ pub trait Elevators {
     fn update_floors(&mut self);
 
     fn increment_wait_times(&mut self);
+
+    fn append_elevator(&mut self, energy_up: f64, energy_down: f64, energy_coef: f64);
 }
 
 //Implementation of elevators trait for Vec<Elevators>
@@ -93,5 +95,10 @@ impl Elevators for Vec<Elevator> {
         for elevator in self.iter_mut() {
             elevator.increment_wait_times();
         }
+    }
+
+    /// Appends a new elevator to the collection of elevators
+    fn append_elevator(&mut self, energy_up: f64, energy_down: f64, energy_coef: f64) {
+        self.push(Elevator::from(energy_up, energy_down, energy_coef));
     }
 }

--- a/src/floors.rs
+++ b/src/floors.rs
@@ -35,6 +35,9 @@ pub trait Floors {
     /// Expected to increment the waiting times among people who are waiting/not at their
     /// destination floor throughout the collection of floors.
     fn increment_wait_times(&mut self);
+
+    /// Expected to append a new floor to the collection of floors.
+    fn append_floor(&mut self);
 }
 
 //Implement people trait for Vec<Floor>
@@ -123,5 +126,10 @@ impl Floors for Vec<Floor> {
         for floor in self.iter_mut() {
             floor.increment_wait_times();
         }
+    }
+
+    /// Appends a new floor to the collection of floors.
+    fn append_floor(&mut self) {
+        self.push(Floor::new());
     }
 }


### PR DESCRIPTION
In this PR, I add the ability to append new floors and new elevators to a building.  This will be one of the main mechanisms underlying the upgrade system in Universal Elevators.