### PR TITLE
RandomController support dynamic number of floors & elevators

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevate-lib"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "An elevator simulation library for Rust"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -32,6 +32,7 @@ pub trait ElevatorController {
 /// reaches its destination floor.
  pub struct RandomController {
     pub building: Building,
+    num_floors: usize,
     floors_to: Vec<Option<usize>>,
     dst_to: Uniform<usize>,
     p_rational: f64,
@@ -84,6 +85,7 @@ impl RandomController {
         //Initialize the controller
         RandomController {
             building: building,
+            num_floors: num_floors,
             floors_to: floors_to,
             dst_to: dst_to,
             p_rational: p_rational,
@@ -121,6 +123,21 @@ impl RandomController {
     /// Set the destination floors of the elevators randomly according to
     /// random or rational logic, depending on the p_rational
     pub fn update_floors_to(&mut self) {
+        //If the number of elevators in the building is greater than the number
+        //of destination floors in the controller, then add new destination
+        //floors
+        while self.building.elevators.len() > self.floors_to.len() {
+            self.floors_to.push(None);
+        }
+
+        //If the numer of floors in the building is greater than the number of
+        //floors tracked by the controller, then update the number of floors
+        //tracked by the controller and re-instantiate the dest distribution
+        if self.building.floors.len() != self.num_floors {
+            self.num_floors = self.building.floors.len();
+            self.dst_to = Uniform::new(0, self.num_floors);
+        }
+
         //Loop through the elevators in the building
         for (i, elevator) in self.building.elevators.iter().enumerate() {
             //If the destination floor for the elevator is None, then update it


### PR DESCRIPTION
I found a bug when running the universal elevators WASM module in my browser in which the RandomController would produce an unreachable exception when adding a new elevator since its `floors_to` value would not match the length of the number of elevators at that point.  I update that issue in this PR, and also account for some issues in the same controller for adding floors.