### PR TITLE
Fix bug in which exchange exceeds first floor capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "elevate-lib"
-version = "0.1.9"
+version = "0.1.0-202403171437+1.0.0-alpha.1"
 dependencies = [
  "rand",
  "statrs",

--- a/cargo.toml
+++ b/cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevate-lib"
-version = "0.1.0-202403171309+1.0.0-alpha.1"
+version = "0.1.0-202403171437+1.0.0-alpha.1"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "An elevator simulation library for Rust"

--- a/src/building.rs
+++ b/src/building.rs
@@ -193,13 +193,26 @@ impl Building {
             //Get the elevator's floor index
             let floor_index: usize = elevator.floor_on;
 
-            //Get the floor and elevator's free capacity
+            //Get the floor's free capacity and the floor's waiting capacity
             let floor_free_capacity: usize = self.floors[floor_index].get_free_capacity();
+            let floor_wait_capacity: usize = self.floors[floor_index].get_num_people_waiting();
+            let floor_exchange_capacity: usize = floor_free_capacity + floor_wait_capacity;
+
+            //Get the elevator's free capacity and the elevator's leaving capacity
             let elevator_free_capacity: usize = elevator.get_free_capacity();
+            let elevator_leav_capacity: usize = elevator.get_num_people_going_to_floor(floor_index);
+            let elevator_exchange_capacity: usize = elevator_free_capacity + elevator_leav_capacity;
+
+            //Calculate the exchange capacity using the floor and elevator capacities
+            let exchange_capacity: usize = if floor_exchange_capacity > elevator_exchange_capacity {
+                floor_exchange_capacity - elevator_exchange_capacity
+            } else {
+                elevator_exchange_capacity - floor_exchange_capacity
+            };
 
             //Move people off the floor and off the elevator
-            let people_leaving_floor: Vec<Person> = self.floors[floor_index].flush_people_entering_elevator(elevator_free_capacity);
-            let mut people_leaving_elevator: Vec<Person> = elevator.flush_people_leaving_elevator(floor_free_capacity);
+            let people_leaving_floor: Vec<Person> = self.floors[floor_index].flush_people_entering_elevator(exchange_capacity);
+            let mut people_leaving_elevator: Vec<Person> = elevator.flush_people_leaving_elevator(exchange_capacity);
 
             //Aggregate the wait times of the people leaving the elevator into the average and reset
             let wait_times: usize = people_leaving_elevator.get_aggregate_wait_time();

--- a/src/elevator.rs
+++ b/src/elevator.rs
@@ -236,6 +236,11 @@ impl People for Elevator {
         self.people.get_num_people_waiting()
     }
 
+    /// Determines the number of people going to a particular floor
+    fn get_num_people_going_to_floor(&self, floor_to: usize) -> usize {
+        self.people.get_num_people_going_to_floor(floor_to)
+    }
+
     /// Reads the wait times from people waiting/not at their desired floor and aggregates
     /// the total into a usize.
     fn get_aggregate_wait_time(&self) -> usize {

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -200,6 +200,11 @@ impl People for Floor {
         self.people.get_num_people_waiting()
     }
 
+    /// Determines the number of people going to a particular floor
+    fn get_num_people_going_to_floor(&self, floor_to: usize) -> usize {
+        self.people.get_num_people_going_to_floor(floor_to)
+    }
+
     /// Reads the wait times from people waiting on the floor/not at their desired floor
     /// and aggregates the total into a usize.
     fn get_aggregate_wait_time(&self) -> usize {

--- a/src/people.rs
+++ b/src/people.rs
@@ -24,6 +24,9 @@ pub trait People {
     /// desired floor.
     fn get_num_people_waiting(&self) -> usize;
 
+    /// Expected to determine the number of people going to a particular floor
+    fn get_num_people_going_to_floor(&self, floor_to: usize) -> usize;
+
     /// Expected to read the wait times from people waiting/not at their desired floor
     /// and aggregate the total into a usize.
     fn get_aggregate_wait_time(&self) -> usize;
@@ -102,6 +105,26 @@ impl People for Vec<Person> {
 
         //Return the counter
         num_waiting
+    }
+
+    /// Determines the number of people going to a particular floor
+    fn get_num_people_going_to_floor(&self, floor_to: usize) -> usize {
+        //Initialize a usize counting the number of people going to the floor
+        let mut num_going_to_floor: usize = 0_usize;
+
+        //Loop through the vector of persons
+        for pers in self.iter() {
+            //Skip if the person is not going to that floor
+            if pers.floor_to != floor_to {
+                continue;
+            }
+
+            //If the person is going to that floor, increment the counter
+            num_going_to_floor += 1_usize;
+        }
+
+        //Return the counter
+        num_going_to_floor
     }
 
     /// Reads the wait times from people waiting/not at their desired floor and aggregates


### PR DESCRIPTION
In this PR, I attempt to fix a bug which caused the `elevate-cli` tool to crash when exchanging people between an elevator and the first floor of the building when the first floor is at capacity.  I'm not 100% sure this will solve the problem, but it definitely hardens the exchange logic a bit more.