### PR TITLE
Fix bug in which capacity is exceeded when using extend

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevate-lib"
-version = "0.1.0-202403171437+1.0.0-alpha.1"
+version = "0.1.0-202403171450+1.0.0-alpha.1"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "An elevator simulation library for Rust"

--- a/src/elevator.rs
+++ b/src/elevator.rs
@@ -198,13 +198,10 @@ impl Elevator {
 //Implement the extend trait for the elevator struct
 impl Extend<Person> for Elevator {
     fn extend<T: IntoIterator<Item=Person>>(&mut self, iter: T) {
-        //Get the current number of people on the elevator
-        let num_people: usize = self.people.get_num_people();
-
         //Add people into the elevator until at capacity
         for pers in iter {
             //Break if we reach capacity
-            if num_people == self.capacity {
+            if self.people.get_num_people() == self.capacity {
                 break;
             }
 

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -160,13 +160,10 @@ impl Floor {
 //Implement the extend trait for the floor struct
 impl Extend<Person> for Floor {
     fn extend<T: IntoIterator<Item=Person>>(&mut self, iter: T) {
-        //Get the current number of people on the floor
-        let num_people: usize = self.people.get_num_people();
-
         //Add people onto the floor until at capacity
         for pers in iter {
             //Break if we reach capacity
-            if num_people == self.capacity {
+            if self.people.get_num_people() == self.capacity {
                 break;
             }
 


### PR DESCRIPTION
In this PR, I fix a bug in which the elevator and floor capacities could be exceeded when using the extend function, since we didn't re-check the free capacity after adding a new person.