### PR TITLE
Update elevator exchange logic to use min of exchange capacities

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevate-lib"
-version = "0.1.0-202403171450+1.0.0-alpha.1"
+version = "0.1.0-202403171545+1.0.0-alpha.1"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "An elevator simulation library for Rust"

--- a/src/building.rs
+++ b/src/building.rs
@@ -205,9 +205,9 @@ impl Building {
 
             //Calculate the exchange capacity using the floor and elevator capacities
             let exchange_capacity: usize = if floor_exchange_capacity > elevator_exchange_capacity {
-                floor_exchange_capacity - elevator_exchange_capacity
+                elevator_exchange_capacity
             } else {
-                elevator_exchange_capacity - floor_exchange_capacity
+                floor_exchange_capacity
             };
 
             //Move people off the floor and off the elevator


### PR DESCRIPTION
In this PR, I attempt to fix a bug in which too many people leave the first floor when the elevator reaches that floor.  This was due to the fact that we were not calculating the min of the exchange capacities between the floor and elevator when an exchange occurs.